### PR TITLE
feat(debian): fixed chinese sources were overwritten by cloud-init

### DIFF
--- a/scripts/deb-11-install.sh
+++ b/scripts/deb-11-install.sh
@@ -14,6 +14,8 @@ if [ "$CN_FLAG" == "true" ]; then
             -e 's|security.debian.org|mirrors.ustc.edu.cn|g' \
             -e 's|deb.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' \
             /etc/apt/sources.list
+    sudo sed -i '/^ - package-update-upgrade-install$/d' /etc/cloud/cloud.cfg
+    sudo sed -i '/^ - apt-configure$/d' /etc/cloud/cloud.cfg
 else
     echo "use default sources"
 fi

--- a/scripts/deb-12-install.sh
+++ b/scripts/deb-12-install.sh
@@ -16,7 +16,8 @@ if [ "$CN_FLAG" == "true" ]; then
                 -e 's|security.debian.org|mirrors.ustc.edu.cn|g' \
                 -e 's|deb.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' \
                 /etc/apt/mirrors/debian-security.list
-
+    sudo sed -i '/^ - package-update-upgrade-install$/d' /etc/cloud/cloud.cfg
+    sudo sed -i '/^ - apt-configure$/d' /etc/cloud/cloud.cfg
 else
     echo "use default sources"
 fi

--- a/scripts/deb-13-install.sh
+++ b/scripts/deb-13-install.sh
@@ -8,6 +8,7 @@ done
 
 echo "==> change repo souces"
 if [ "$CN_FLAG" == "true" ]; then
+    echo "use CN sources"
     CN_MIRROR="mirrors.ustc.edu.cn"
     MAIN_MIRROR_FILE="/etc/apt/mirrors/debian.list"
     SECURITY_MIRROR_FILE="/etc/apt/mirrors/debian-security.list"
@@ -15,6 +16,8 @@ if [ "$CN_FLAG" == "true" ]; then
     sudo sed -i -e "s|security.debian.org/debian-security|${CN_MIRROR}/debian-security|g" \
                 -e "s|deb.debian.org/debian-security|${CN_MIRROR}/debian-security|g" \
                 -e "s|security.debian.org|${CN_MIRROR}|g" "$SECURITY_MIRROR_FILE"
+    sudo sed -i '/^ - package-update-upgrade-install$/d' /etc/cloud/cloud.cfg
+    sudo sed -i '/^ - apt-configure$/d' /etc/cloud/cloud.cfg
 else
     echo "use default sources"
 fi


### PR DESCRIPTION
Disable cloud-init's package-update-upgrade-install and apt-configure modules in Debian 11, 12, and 13 scripts to prevent interference with pre-configured Chinese software sources.

This ensures that cloud-init does not override the China mirror configuration that has already been properly set up in the scripts.